### PR TITLE
preserve existing sentences in model on consume!

### DIFF
--- a/lib/moo_ebooks/model.rb
+++ b/lib/moo_ebooks/model.rb
@@ -225,8 +225,13 @@ module Ebooks
         @sentences << sentence
       end
       
-      # this needs to be rewritten to merge the resulting arrays together
-      @keywords = NLP.keywords("#{text}\n#{@keywords.join("\n")}").top(200).map(&:to_s)
+      # if we're gonna keep the keyword limit at 200 and we want to preserve
+      #  our old keywords array then my solution is to union the new array
+      #  with the old, randomize them and take the first 200
+      @keywords = @keywords.union(NLP
+                                    .keywords(text)
+                                    .top(200)
+                                    .map(&:to_s)).sample(200)
 
       nil
     end
@@ -239,7 +244,11 @@ module Ebooks
       end
 
       mention_text = mentions.join("\n").encode('UTF-8', invalid: :replace)
-      @mentions = mass_tikify(mention_text)
+      # the same as above, we just add onto our array instead of
+      #  overwriting it
+      mass_tikify(mention_text).each do |mention|
+        @mentions << mention
+      end
 
       nil
     end

--- a/lib/moo_ebooks/model.rb
+++ b/lib/moo_ebooks/model.rb
@@ -218,8 +218,15 @@ module Ebooks
       end
 
       text = statuses.join("\n").encode('UTF-8', invalid: :replace)
-      @sentences = mass_tikify(text)
-      @keywords = NLP.keywords(text).top(200).map(&:to_s)
+
+      # adds the new sentence structures into the sentence array
+      #  instead of overwriting it
+      mass_tikify(text).each do |sentence|
+        @sentences << sentence
+      end
+      
+      # this needs to be rewritten to merge the resulting arrays together
+      @keywords = NLP.keywords("#{text}\n#{@keywords.join("\n")}").top(200).map(&:to_s)
 
       nil
     end


### PR DESCRIPTION
Changes proposed in this pull request:

Fixes:
overwriting saved sentences/mentions/keywords on consuming new content.

@maxine-red/moo_ebooks
